### PR TITLE
Updating integration to handle integers instead of booleans. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
   //Taplytics
-  compile('com.taplytics.sdk:taplytics:1.10.4')
+  compile('com.taplytics.sdk:taplytics:1.11.6')
   compile 'com.android.volley:volley:1.0.0'
 
   testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
   //Taplytics
-  compile('com.taplytics.sdk:taplytics:1.10.2')
+  compile('com.taplytics.sdk:taplytics:1.10.4')
   compile 'com.android.volley:volley:1.0.0'
 
   testCompile 'junit:junit:4.12'

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -9,12 +9,12 @@ import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.TrackPayload;
 import com.taplytics.sdk.Taplytics;
 
+import org.json.JSONObject;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.json.JSONObject;
 
 import static com.segment.analytics.internal.Utils.transform;
 
@@ -39,11 +39,13 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
     private static final String TAPLYTICS_OPTION_LIVE_UPDATE = "liveUpdate";
     private static final String TAPLYTICS_OPTION_SHAKE_MENU = "shakeMenu";
     private static final String TAPLYTICS_OPTION_TURN_MENU = "turnMenu";
-    private static final String TAPLYTICS_OPTION_LIVE_UPDATE_V2 = "liveUpdate_v2";
-    private static final String TAPLYTICS_OPTION_SHAKE_MENU_V2 = "shakeMenu_v2";
-    private static final String TAPLYTICS_OPTION_TURN_MENU_V2 = "turnMenu_v2";
     private static final String TAPLYTICS_OPTION_SESSION_MINUTES = "sessionMinutes";
     private static final String TAPLYTICS_OPTION_DELAYED_START = "delayedStartTaplytics";
+
+     static final int DISABLED = 0;
+     static final int ENABLED = 1;
+     static final int DEFAULT = 2;
+
 
     private static final Map<String, String> MAPPER;
 
@@ -55,33 +57,30 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
         MAPPER = Collections.unmodifiableMap(mapper);
     }
 
-    private enum TaplyticsValue {
-        OFF(false), ON(true), DEFAULT(null);
-
-        private Boolean value = null;
-
-        TaplyticsValue(Boolean val) {
-            this.value = val;
-        }
-
-        public Boolean getValue() {
-            return value;
-        }
-    }
-
     private final Logger logger;
+
+    int liveUpdate;
+    int shakeMenu;
+    int turnMenu;
+    int sessionMinutes;
 
     TaplyticsIntegration(Analytics analytics, ValueMap settings) {
         logger = analytics.logger(TAPLYTICS_KEY);
         String apiKey = settings.getString(TAPLYTICS_KEY_API_KEY);
-        int liveUpdate = settings.getInt(TAPLYTICS_OPTION_LIVE_UPDATE_V2, TaplyticsValue.DEFAULT.ordinal());
-        int shakeMenu = settings.getInt(TAPLYTICS_OPTION_SHAKE_MENU_V2, TaplyticsValue.DEFAULT.ordinal());
-        int turnMenu = settings.getInt(TAPLYTICS_OPTION_TURN_MENU_V2, TaplyticsValue.DEFAULT.ordinal());
-        int sessionMinutes = settings.getInt(TAPLYTICS_OPTION_SESSION_MINUTES, 10);
+        liveUpdate = settings.getInt(TAPLYTICS_OPTION_LIVE_UPDATE, DEFAULT);
+        shakeMenu = settings.getInt(TAPLYTICS_OPTION_SHAKE_MENU, DEFAULT);
+        turnMenu = settings.getInt(TAPLYTICS_OPTION_TURN_MENU, DEFAULT);
+        sessionMinutes = settings.getInt(TAPLYTICS_OPTION_SESSION_MINUTES, 10);
         HashMap<String, Object> options = new HashMap<>();
-        options.put(TAPLYTICS_OPTION_LIVE_UPDATE, TaplyticsValue.values()[liveUpdate].value);
-        options.put(TAPLYTICS_OPTION_SHAKE_MENU, TaplyticsValue.values()[shakeMenu].value);
-        options.put(TAPLYTICS_OPTION_TURN_MENU, TaplyticsValue.values()[turnMenu].value);
+        if (liveUpdate != DEFAULT) {
+            options.put(TAPLYTICS_OPTION_LIVE_UPDATE, liveUpdate != DISABLED);
+        }
+        if (shakeMenu != DEFAULT) {
+            options.put(TAPLYTICS_OPTION_SHAKE_MENU, shakeMenu != DISABLED);
+        }
+        if (turnMenu != DEFAULT) {
+            options.put(TAPLYTICS_OPTION_TURN_MENU, turnMenu != DISABLED);
+        }
         options.put(TAPLYTICS_OPTION_SESSION_MINUTES, sessionMinutes);
         options.put(TAPLYTICS_OPTION_DELAYED_START, true);
         Taplytics.startTaplytics(analytics.getApplication(), apiKey, options);

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -51,7 +51,7 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
   }
 
   private enum TaplyticsValue {
-    DEFAULT(null), ON(true), OFF(false);
+    OFF(false), ON(true), DEFAULT(null);
 
     private Boolean value = null;
 
@@ -70,8 +70,8 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
     logger = analytics.logger(TAPLYTICS_KEY);
     String apiKey = settings.getString(TAPLYTICS_KEY_API_KEY);
     int liveUpdate = settings.getInt(TAPLYTICS_OPTION_LIVE_UPDATE, TaplyticsValue.DEFAULT.ordinal());
-    int shakeMenu = settings.getInt(TAPLYTICS_OPTION_SHAKE_MENU, 0);
-    int turnMenu = settings.getInt(TAPLYTICS_OPTION_TURN_MENU, 0);
+    int shakeMenu = settings.getInt(TAPLYTICS_OPTION_SHAKE_MENU, TaplyticsValue.DEFAULT.ordinal());
+    int turnMenu = settings.getInt(TAPLYTICS_OPTION_TURN_MENU, TaplyticsValue.DEFAULT.ordinal());
     int sessionMinutes = settings.getInt(TAPLYTICS_OPTION_SESSION_MINUTES, 10);
     HashMap<String, Object> options = new HashMap<>();
     options.put(TAPLYTICS_OPTION_LIVE_UPDATE, TaplyticsValue.values()[liveUpdate].value);

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -39,9 +39,9 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
     private static final String TAPLYTICS_OPTION_LIVE_UPDATE = "liveUpdate";
     private static final String TAPLYTICS_OPTION_SHAKE_MENU = "shakeMenu";
     private static final String TAPLYTICS_OPTION_TURN_MENU = "turnMenu";
-    private static final String TAPLYTICS_OPTION_LIVE_UPDATE_V2 = "liveUpdateV2";
-    private static final String TAPLYTICS_OPTION_SHAKE_MENU_V2 = "shakeMenuV2";
-    private static final String TAPLYTICS_OPTION_TURN_MENU_V2 = "turnMenuV2";
+    private static final String TAPLYTICS_OPTION_LIVE_UPDATE_V2 = "liveUpdate_v2";
+    private static final String TAPLYTICS_OPTION_SHAKE_MENU_V2 = "shakeMenu_v2";
+    private static final String TAPLYTICS_OPTION_TURN_MENU_V2 = "turnMenu_v2";
     private static final String TAPLYTICS_OPTION_SESSION_MINUTES = "sessionMinutes";
     private static final String TAPLYTICS_OPTION_DELAYED_START = "delayedStartTaplytics";
 

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -8,10 +8,12 @@ import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.TrackPayload;
 import com.taplytics.sdk.Taplytics;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import org.json.JSONObject;
 
 import static com.segment.analytics.internal.Utils.transform;
@@ -20,92 +22,95 @@ import static com.segment.analytics.internal.Utils.transform;
  * Created by williamjohnson on 4/19/16.
  */
 public class TaplyticsIntegration extends Integration<Taplytics> {
-  public static final Factory FACTORY = new Factory() {
-    @Override
-    public Integration<?> create(ValueMap settings, Analytics analytics) {
-      return new TaplyticsIntegration(analytics, settings);
+    public static final Factory FACTORY = new Factory() {
+        @Override
+        public Integration<?> create(ValueMap settings, Analytics analytics) {
+            return new TaplyticsIntegration(analytics, settings);
+        }
+
+        @Override
+        public String key() {
+            return TAPLYTICS_KEY;
+        }
+    };
+
+    private static final String TAPLYTICS_KEY = "Taplytics";
+    private static final String TAPLYTICS_KEY_API_KEY = "apiKey";
+    private static final String TAPLYTICS_OPTION_LIVE_UPDATE = "liveUpdate";
+    private static final String TAPLYTICS_OPTION_SHAKE_MENU = "shakeMenu";
+    private static final String TAPLYTICS_OPTION_TURN_MENU = "turnMenu";
+    private static final String TAPLYTICS_OPTION_LIVE_UPDATE_V2 = "liveUpdateV2";
+    private static final String TAPLYTICS_OPTION_SHAKE_MENU_V2 = "shakeMenuV2";
+    private static final String TAPLYTICS_OPTION_TURN_MENU_V2 = "turnMenuV2";
+    private static final String TAPLYTICS_OPTION_SESSION_MINUTES = "sessionMinutes";
+    private static final String TAPLYTICS_OPTION_DELAYED_START = "delayedStartTaplytics";
+
+    private static final Map<String, String> MAPPER;
+
+    static {
+        Map<String, String> mapper = new LinkedHashMap<>();
+        mapper.put("firstName", "firstname");
+        mapper.put("lastName", "lastname");
+        mapper.put("userId", "user_id");
+        MAPPER = Collections.unmodifiableMap(mapper);
+    }
+
+    private enum TaplyticsValue {
+        OFF(false), ON(true), DEFAULT(null);
+
+        private Boolean value = null;
+
+        TaplyticsValue(Boolean val) {
+            this.value = val;
+        }
+
+        public Boolean getValue() {
+            return value;
+        }
+    }
+
+    private final Logger logger;
+
+    TaplyticsIntegration(Analytics analytics, ValueMap settings) {
+        logger = analytics.logger(TAPLYTICS_KEY);
+        String apiKey = settings.getString(TAPLYTICS_KEY_API_KEY);
+        int liveUpdate = settings.getInt(TAPLYTICS_OPTION_LIVE_UPDATE_V2, TaplyticsValue.DEFAULT.ordinal());
+        int shakeMenu = settings.getInt(TAPLYTICS_OPTION_SHAKE_MENU_V2, TaplyticsValue.DEFAULT.ordinal());
+        int turnMenu = settings.getInt(TAPLYTICS_OPTION_TURN_MENU_V2, TaplyticsValue.DEFAULT.ordinal());
+        int sessionMinutes = settings.getInt(TAPLYTICS_OPTION_SESSION_MINUTES, 10);
+        HashMap<String, Object> options = new HashMap<>();
+        options.put(TAPLYTICS_OPTION_LIVE_UPDATE, TaplyticsValue.values()[liveUpdate].value);
+        options.put(TAPLYTICS_OPTION_SHAKE_MENU, TaplyticsValue.values()[shakeMenu].value);
+        options.put(TAPLYTICS_OPTION_TURN_MENU, TaplyticsValue.values()[turnMenu].value);
+        options.put(TAPLYTICS_OPTION_SESSION_MINUTES, sessionMinutes);
+        options.put(TAPLYTICS_OPTION_DELAYED_START, true);
+        Taplytics.startTaplytics(analytics.getApplication(), apiKey, options);
+        logger.verbose("Taplytics.startTaplytics(analytics.getApplication(), %s, %s)", apiKey, options);
     }
 
     @Override
-    public String key() {
-      return TAPLYTICS_KEY;
-    }
-  };
-
-  private static final String TAPLYTICS_KEY = "Taplytics";
-  private static final String TAPLYTICS_KEY_API_KEY = "apiKey";
-  private static final String TAPLYTICS_OPTION_LIVE_UPDATE = "liveUpdate";
-  private static final String TAPLYTICS_OPTION_SHAKE_MENU = "shakeMenu";
-  private static final String TAPLYTICS_OPTION_TURN_MENU = "turnMenu";
-  private static final String TAPLYTICS_OPTION_SESSION_MINUTES = "sessionMinutes";
-  private static final String TAPLYTICS_OPTION_DELAYED_START = "delayedStartTaplytics";
-
-  private static final Map<String, String> MAPPER;
-
-  static {
-    Map<String, String> mapper = new LinkedHashMap<>();
-    mapper.put("firstName", "firstname");
-    mapper.put("lastName", "lastname");
-    mapper.put("userId", "user_id");
-    MAPPER = Collections.unmodifiableMap(mapper);
-  }
-
-  private enum TaplyticsValue {
-    OFF(false), ON(true), DEFAULT(null);
-
-    private Boolean value = null;
-
-    TaplyticsValue(Boolean val) {
-      this.value = val;
+    public void track(TrackPayload track) {
+        String event = track.event();
+        event(event, track.properties());
     }
 
-    public Boolean getValue() {
-      return value;
+    @Override
+    public void identify(IdentifyPayload identify) {
+        super.identify(identify);
+        JSONObject traits = new ValueMap(transform(identify.traits(), MAPPER)).toJsonObject();
+        Taplytics.setUserAttributes(traits);
+        logger.verbose("Taplytics.setUserAttributes(%s)", traits);
     }
-  }
 
-  private final Logger logger;
-
-  TaplyticsIntegration(Analytics analytics, ValueMap settings) {
-    logger = analytics.logger(TAPLYTICS_KEY);
-    String apiKey = settings.getString(TAPLYTICS_KEY_API_KEY);
-    int liveUpdate = settings.getInt(TAPLYTICS_OPTION_LIVE_UPDATE, TaplyticsValue.DEFAULT.ordinal());
-    int shakeMenu = settings.getInt(TAPLYTICS_OPTION_SHAKE_MENU, TaplyticsValue.DEFAULT.ordinal());
-    int turnMenu = settings.getInt(TAPLYTICS_OPTION_TURN_MENU, TaplyticsValue.DEFAULT.ordinal());
-    int sessionMinutes = settings.getInt(TAPLYTICS_OPTION_SESSION_MINUTES, 10);
-    HashMap<String, Object> options = new HashMap<>();
-    options.put(TAPLYTICS_OPTION_LIVE_UPDATE, TaplyticsValue.values()[liveUpdate].value);
-    options.put(TAPLYTICS_OPTION_SHAKE_MENU, TaplyticsValue.values()[shakeMenu].value);
-    options.put(TAPLYTICS_OPTION_TURN_MENU, TaplyticsValue.values()[turnMenu].value);
-    options.put(TAPLYTICS_OPTION_SESSION_MINUTES, sessionMinutes);
-    options.put(TAPLYTICS_OPTION_DELAYED_START, true);
-    Taplytics.startTaplytics(analytics.getApplication(), apiKey, options);
-    logger.verbose("Taplytics.startTaplytics(analytics.getApplication(), %s, %s)", apiKey, options);
-  }
-
-  @Override
-  public void track(TrackPayload track) {
-    String event = track.event();
-    event(event, track.properties());
-  }
-
-  @Override
-  public void identify(IdentifyPayload identify) {
-    super.identify(identify);
-    JSONObject traits = new ValueMap(transform(identify.traits(), MAPPER)).toJsonObject();
-    Taplytics.setUserAttributes(traits);
-    logger.verbose("Taplytics.setUserAttributes(%s)", traits);
-  }
-
-  private void event(String name, Properties properties) {
-    JSONObject propertiesJSON = properties.toJsonObject();
-    int revenue = (int) properties.revenue();
-    if (revenue != 0) {
-      Taplytics.logRevenue(name, revenue, propertiesJSON);
-      logger.verbose("Taplytics.logRevenue(%s, %s, %s)", name, revenue, propertiesJSON);
-      return;
+    private void event(String name, Properties properties) {
+        JSONObject propertiesJSON = properties.toJsonObject();
+        int revenue = (int) properties.revenue();
+        if (revenue != 0) {
+            Taplytics.logRevenue(name, revenue, propertiesJSON);
+            logger.verbose("Taplytics.logRevenue(%s, %s, %s)", name, revenue, propertiesJSON);
+            return;
+        }
+        Taplytics.logEvent(name, properties.value(), propertiesJSON);
+        logger.verbose("Taplytics.logEvent(%s, %s, %s)", name, properties.value(), propertiesJSON);
     }
-    Taplytics.logEvent(name, properties.value(), propertiesJSON);
-    logger.verbose("Taplytics.logEvent(%s, %s, %s)", name, properties.value(), propertiesJSON);
-  }
 };

--- a/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
@@ -59,7 +59,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
   @Test public void factory() {
     ValueMap settings = new ValueMap() //
-        .putValue("apiKey", "foo").putValue("liveUpdate", false).putValue("sessionMinutes", 20);
+        .putValue("apiKey", "foo").putValue("liveUpdate", 2).putValue("sessionMinutes", 20);
     TaplyticsIntegration integration =
         (TaplyticsIntegration) TaplyticsIntegration.FACTORY.create(settings, analytics);
     verifyStatic();
@@ -80,7 +80,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
   }
 
   @Test public void activityCreate() {
-    ValueMap settings = new ValueMap().putValue("turnMenu", false).putValue("sessionMinutes", 10).putValue("liveUpdate", true).putValue("shakeMenu", true).putValue("delayedStartTaplytics", true);
+    ValueMap settings = new ValueMap().putValue("turnMenu", 2).putValue("sessionMinutes", 10).putValue("liveUpdate", 1).putValue("shakeMenu", 1).putValue("delayedStartTaplytics", 1);
     Activity activity = mock(Activity.class);
     Bundle bundle = mock(Bundle.class);
     integration.onActivityCreated(activity, bundle);

--- a/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
@@ -59,11 +59,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
   @Test public void factory() {
     ValueMap settings = new ValueMap() //
-        .putValue("apiKey", "foo").putValue("liveUpdate", 2).putValue("sessionMinutes", 20);
+        .putValue("apiKey", "foo").putValue("liveUpdate", TaplyticsIntegration.DEFAULT).putValue("sessionMinutes", 20);
     TaplyticsIntegration integration =
         (TaplyticsIntegration) TaplyticsIntegration.FACTORY.create(settings, analytics);
     verifyStatic();
-    assertThat(integration.liveUpdate).isFalse();
+    assertThat(integration.liveUpdate).isEqualTo(TaplyticsIntegration.DEFAULT);
     assertThat(integration.sessionMinutes).isEqualTo(20);
   }
 
@@ -75,7 +75,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
     verifyStatic();
     //Integration initialized
     //Make sure settings are set correctly
-    assertThat(integration.liveUpdate).isTrue();
+    assertThat(integration.liveUpdate).isEqualTo(TaplyticsIntegration.DEFAULT);
     assertThat(integration.sessionMinutes).isEqualTo(10);
   }
 


### PR DESCRIPTION
Currently, Segment does not support sending down a 'null' value for options that have a 'default' setting (or rather, it can either be true or false or the system will decide it).

I've changed it around to accept 0,1,2 as the values, which map to an enumerator containing Default/On/Off representing null/true/false. The taplytics SDK will handle this accordingly.
