### PR TITLE
Bump Taplytics SDK to 1.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
   // Taplytics.
-  compile('com.taplytics.sdk:taplytics:1.17.1')
+  compile('com.taplytics.sdk:taplytics:1.20.0')
   compile 'com.android.volley:volley:1.0.0'
 
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
I think we should bump the Taplytics SDK to the latest version and be sure to test initialization against this, just in case. Using an older version logs a warning to the Android Monitor: "A Taplytics SDK update is available. Please update to ensure best functionality".