### PR TITLE
Bump Taplytics dep to 1.21.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
   // Taplytics.
-  compile('com.taplytics.sdk:taplytics:1.20.0')
+  compile 'com.taplytics.sdk:taplytics:1.21.0'
   compile 'com.android.volley:volley:1.0.0'
 
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
- Updates Bugsnag dep to 1.21.0
- No Android IDE errors as a result of the bump
- All unit tests pass
- CircleCI passes
- This version adds support for Android and Fire TV