### PR TITLE
Track Segment screens as Taplytics events

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -6,6 +6,7 @@ import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
+import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 import com.taplytics.sdk.Taplytics;
 import java.util.Collections;
@@ -32,6 +33,7 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
       };
 
   private static final String TAPLYTICS_KEY = "Taplytics";
+  private static final String SCREEN_EVENT_FORMAT = "Viewed %s screen";
 
   static final Map<String, String> MAPPER;
 
@@ -96,6 +98,12 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
   public void track(TrackPayload track) {
     String event = track.event();
     event(event, track.properties());
+  }
+
+  @Override
+  public void screen(ScreenPayload screen) {
+    String name = String.format(SCREEN_EVENT_FORMAT, screen.name());
+    event(name, screen.properties());
   }
 
   @Override


### PR DESCRIPTION
**Motivation**: At TodayTix, it would be helpful for us to use a screen event as a denominator for Taplytics experiment goals. Currently, this integration only forwards Segment `track` events to Taplytics, so we are unable to do that.

**Proposal**: This PR adds functionality that forwards `screen` events as well. We propose the format `Viewed {screen_name} screen` to build the Taplytics event name from the screen name. 

Ideally, specifying whether or not `screen` events are forwarded should be toggle-able via this integration's settings in the Segment dashboard. If a setting was added to the dashboard, we could update this PR to read the variable and determine whether or not to forward screens.
